### PR TITLE
:rewind: revert experiment with PrivateAssets set to compile

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -81,7 +81,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Codebelt.Extensions.Xunit" Version="9.0.0-preview.6" />
+    <PackageReference Include="Codebelt.Extensions.Xunit" Version="9.0.0-preview.6" PrivateAssets="all" />
   </ItemGroup>
 
 </Project>

--- a/src/Codebelt.Extensions.AspNetCore.Mvc.Formatters.Text.Yaml/Codebelt.Extensions.AspNetCore.Mvc.Formatters.Text.Yaml.csproj
+++ b/src/Codebelt.Extensions.AspNetCore.Mvc.Formatters.Text.Yaml/Codebelt.Extensions.AspNetCore.Mvc.Formatters.Text.Yaml.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Cuemon.AspNetCore.Mvc" Version="9.0.0-preview.9" PrivateAssets="compile" />
+    <PackageReference Include="Cuemon.AspNetCore.Mvc" Version="9.0.0-preview.9" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Codebelt.Extensions.AspNetCore.Text.Yaml/Codebelt.Extensions.AspNetCore.Text.Yaml.csproj
+++ b/src/Codebelt.Extensions.AspNetCore.Text.Yaml/Codebelt.Extensions.AspNetCore.Text.Yaml.csproj
@@ -11,8 +11,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Cuemon.AspNetCore" Version="9.0.0-preview.9" PrivateAssets="compile" />
-    <PackageReference Include="Cuemon.Extensions.DependencyInjection" Version="9.0.0-preview.9" PrivateAssets="compile" />
+    <PackageReference Include="Cuemon.AspNetCore" Version="9.0.0-preview.9" />
+    <PackageReference Include="Cuemon.Extensions.DependencyInjection" Version="9.0.0-preview.9" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Codebelt.Extensions.YamlDotNet/Codebelt.Extensions.YamlDotNet.csproj
+++ b/src/Codebelt.Extensions.YamlDotNet/Codebelt.Extensions.YamlDotNet.csproj
@@ -10,7 +10,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Cuemon.Extensions.IO" Version="9.0.0-preview.9" PrivateAssets="compile" />
+    <PackageReference Include="Cuemon.Extensions.Reflection" Version="9.0.0-preview.9" />
+    <PackageReference Include="Cuemon.Extensions.IO" Version="9.0.0-preview.9" />
     <PackageReference Include="YamlDotNet" Version="16.1.3" />
   </ItemGroup>
 

--- a/src/Codebelt.Extensions.YamlDotNet/GlobalSuppressions.cs
+++ b/src/Codebelt.Extensions.YamlDotNet/GlobalSuppressions.cs
@@ -5,5 +5,7 @@
 
 using System.Diagnostics.CodeAnalysis;
 
-[assembly: SuppressMessage("Major Code Smell", "S3011:Reflection should not be used to increase accessibility of classes, methods, or fields", Justification = "By design.", Scope = "member", Target = "~M:Cuemon.Extensions.YamlDotNet.Formatters.YamlFormatter.Serialize(System.Object,System.Type)~System.IO.Stream")]
-[assembly: SuppressMessage("Major Code Smell", "S3011:Reflection should not be used to increase accessibility of classes, methods, or fields", Justification = "By design.", Scope = "member", Target = "~M:Cuemon.Extensions.YamlDotNet.Formatters.YamlFormatter.Deserialize(System.IO.Stream,System.Type)~System.Object")]
+[assembly: SuppressMessage("Major Code Smell", "S3011:Reflection should not be used to increase accessibility of classes, methods, or fields", Justification = "By design.", Scope = "member", Target = "~M:Codebelt.Extensions.YamlDotNet.Formatters.YamlFormatter.Serialize(System.Object,System.Type)~System.IO.Stream")]
+[assembly: SuppressMessage("Major Code Smell", "S3011:Reflection should not be used to increase accessibility of classes, methods, or fields", Justification = "By design.", Scope = "member", Target = "~M:Codebelt.Extensions.YamlDotNet.Formatters.YamlFormatter.Deserialize(System.IO.Stream,System.Type)~System.Object")]
+[assembly: SuppressMessage("Major Code Smell", "S3011:Reflection should not be used to increase accessibility of classes, methods, or fields", Justification = "By design.", Scope = "member", Target = "~M:Codebelt.Extensions.YamlDotNet.Formatters.YamlFormatter.UseDeserializerBuilder~YamlDotNet.Serialization.DeserializerBuilder")]
+[assembly: SuppressMessage("Major Code Smell", "S3011:Reflection should not be used to increase accessibility of classes, methods, or fields", Justification = "By design.", Scope = "member", Target = "~M:Codebelt.Extensions.YamlDotNet.Formatters.YamlFormatter.UseSerializerBuilder~YamlDotNet.Serialization.SerializerBuilder")]


### PR DESCRIPTION
#### PR Classification
Code cleanup and dependency management improvements.

#### PR Summary
Updated package references and suppression targets to improve dependency management and code organization.
- `Directory.Build.props`: Added `PrivateAssets="all"` to `Codebelt.Extensions.Xunit` package reference,
- `Codebelt.Extensions.AspNetCore.Mvc.Formatters.Text.Yaml.csproj`: Removed `PrivateAssets="compile"` from `Cuemon.AspNetCore.Mvc` package reference,
- `Codebelt.Extensions.AspNetCore.Text.Yaml.csproj`: Removed `PrivateAssets="compile"` from `Cuemon.AspNetCore` and `Cuemon.Extensions.DependencyInjection` package references,
- `Codebelt.Extensions.YamlDotNet.csproj`: Added `Cuemon.Extensions.Reflection` package reference and removed `PrivateAssets="compile"` from `Cuemon.Extensions.IO` package reference,
- `GlobalSuppressions.cs`: Updated target namespace and added new suppressions for `UseDeserializerBuilder` and `UseSerializerBuilder` methods.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced new package reference for `Cuemon.Extensions.Reflection`.
- **Bug Fixes**
	- Updated `SuppressMessage` attributes to reflect the correct namespace for serialization methods.
	- Added suppressions for new methods related to deserialization and serialization builders.
- **Chores**
	- Adjusted package references to enhance encapsulation of dependencies across various projects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->