### PR TITLE
V9.0.7/service update

### DIFF
--- a/.docfx/Dockerfile.docfx
+++ b/.docfx/Dockerfile.docfx
@@ -1,4 +1,4 @@
-﻿ARG NGINX_VERSION=1.29.0-alpine
+﻿ARG NGINX_VERSION=1.29.1-alpine
 
 FROM --platform=$BUILDPLATFORM nginx:${NGINX_VERSION} AS base
 RUN rm -rf /usr/share/nginx/html/*

--- a/.github/workflows/pipelines.yml
+++ b/.github/workflows/pipelines.yml
@@ -60,7 +60,8 @@ jobs:
       runs-on: ${{ matrix.os }}
       test-arguments: -- RunConfiguration.DisableAppDomain=true
       build-switches: -p:SkipSignAssembly=true
-      restore: true
+      restore: true # net48 requires packages to be restored
+      build: true # net48 requires projects to be built
 
   sonarcloud:
     name: call-sonarcloud

--- a/.nuget/Codebelt.Extensions.AspNetCore.Mvc.Formatters.Text.Yaml/PackageReleaseNotes.txt
+++ b/.nuget/Codebelt.Extensions.AspNetCore.Mvc.Formatters.Text.Yaml/PackageReleaseNotes.txt
@@ -1,4 +1,10 @@
-﻿Version 9.0.6
+﻿Version 9.0.7
+Availability: .NET 9 and .NET 8
+ 
+# ALM
+- CHANGED Dependencies have been upgraded to the latest compatible versions for all supported target frameworks (TFMs)
+ 
+Version 9.0.6
 Availability: .NET 9 and .NET 8
  
 # ALM

--- a/.nuget/Codebelt.Extensions.AspNetCore.Text.Yaml/PackageReleaseNotes.txt
+++ b/.nuget/Codebelt.Extensions.AspNetCore.Text.Yaml/PackageReleaseNotes.txt
@@ -1,4 +1,10 @@
-﻿Version 9.0.6
+﻿Version 9.0.7
+Availability: .NET 9 and .NET 8
+ 
+# ALM
+- CHANGED Dependencies have been upgraded to the latest compatible versions for all supported target frameworks (TFMs)
+ 
+Version 9.0.6
 Availability: .NET 9 and .NET 8
  
 # ALM

--- a/.nuget/Codebelt.Extensions.YamlDotNet.App/PackageReleaseNotes.txt
+++ b/.nuget/Codebelt.Extensions.YamlDotNet.App/PackageReleaseNotes.txt
@@ -1,4 +1,10 @@
-﻿Version 9.0.6
+﻿Version 9.0.7
+Availability: .NET 9 and .NET 8
+ 
+# ALM
+- CHANGED Dependencies have been upgraded to the latest compatible versions for all supported target frameworks (TFMs)
+ 
+Version 9.0.6
 Availability: .NET 9 and .NET 8
  
 # ALM

--- a/.nuget/Codebelt.Extensions.YamlDotNet/PackageReleaseNotes.txt
+++ b/.nuget/Codebelt.Extensions.YamlDotNet/PackageReleaseNotes.txt
@@ -1,4 +1,10 @@
-﻿Version 9.0.6
+﻿Version 9.0.7
+Availability: .NET 9, .NET 8 and .NET Standard 2.0
+ 
+# ALM
+- CHANGED Dependencies have been upgraded to the latest compatible versions for all supported target frameworks (TFMs)
+ 
+Version 9.0.6
 Availability: .NET 9, .NET 8 and .NET Standard 2.0
  
 # ALM

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ For more details, please refer to `PackageReleaseNotes.txt` on a per assembly ba
 > [!NOTE]  
 > Changelog entries prior to version 8.4.0 was migrated from previous versions of `Cuemon.Extensions.YamlDotNet`, `Cuemon.Extensions.AspNetCore`, `Cuemon.Extensions.AspNetCore.Mvc` and `Cuemon.Extensions.Diagnostics`.
 
+## [9.0.7] - 2025-09-15
+
+This is a service update that focuses on package dependencies.
+
 ## [9.0.6] - 2025-08-16
 
 This is a service update that focuses on package dependencies.

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,16 +3,16 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="Codebelt.Extensions.Xunit" Version="10.0.5" />
-    <PackageVersion Include="Codebelt.Extensions.Xunit.Hosting.AspNetCore" Version="10.0.5" />
-    <PackageVersion Include="Cuemon.AspNetCore" Version="9.0.8" />
-    <PackageVersion Include="Cuemon.AspNetCore.Mvc" Version="9.0.8" />
-    <PackageVersion Include="Cuemon.Extensions.AspNetCore" Version="9.0.8" />
-    <PackageVersion Include="Cuemon.Extensions.AspNetCore.Authentication" Version="9.0.8" />
-    <PackageVersion Include="Cuemon.Extensions.Core" Version="9.0.8" />
-    <PackageVersion Include="Cuemon.Extensions.DependencyInjection" Version="9.0.8" />
-    <PackageVersion Include="Cuemon.Extensions.IO" Version="9.0.8" />
-    <PackageVersion Include="Cuemon.Extensions.Reflection" Version="9.0.8" />
+    <PackageVersion Include="Codebelt.Extensions.Xunit" Version="10.0.6" />
+    <PackageVersion Include="Codebelt.Extensions.Xunit.Hosting.AspNetCore" Version="10.0.6" />
+    <PackageVersion Include="Cuemon.AspNetCore" Version="9.0.9" />
+    <PackageVersion Include="Cuemon.AspNetCore.Mvc" Version="9.0.9" />
+    <PackageVersion Include="Cuemon.Extensions.AspNetCore" Version="9.0.9" />
+    <PackageVersion Include="Cuemon.Extensions.AspNetCore.Authentication" Version="9.0.9" />
+    <PackageVersion Include="Cuemon.Extensions.Core" Version="9.0.9" />
+    <PackageVersion Include="Cuemon.Extensions.DependencyInjection" Version="9.0.9" />
+    <PackageVersion Include="Cuemon.Extensions.IO" Version="9.0.9" />
+    <PackageVersion Include="Cuemon.Extensions.Reflection" Version="9.0.9" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageVersion Include="MinVer" Version="6.0.0" />
     <PackageVersion Include="System.Net.Http" Version="4.3.4" />

--- a/testenvironments.json
+++ b/testenvironments.json
@@ -9,7 +9,7 @@
         {
             "name": "Docker-Ubuntu",
             "type": "docker",
-            "dockerImage": "gimlichael/ubuntu-testrunner:net8.0.413-9.0.304"
+            "dockerImage": "gimlichael/ubuntu-testrunner:net8.0.414-9.0.305"
         }
     ]
 }


### PR DESCRIPTION
This pull request is a service update focused on upgrading package dependencies to their latest compatible versions across the codebase. It also includes minor updates to documentation and Docker image versions to ensure compatibility and stability.

Dependency upgrades:

* Updated all `Cuemon.*` and `Codebelt.Extensions.Xunit*` package versions in `Directory.Packages.props` to their latest releases, improving compatibility and stability.
* Upgraded dependencies for all supported target frameworks in the release notes for `Codebelt.Extensions.YamlDotNet`, `Codebelt.Extensions.YamlDotNet.App`, `Codebelt.Extensions.AspNetCore.Text.Yaml`, and `Codebelt.Extensions.AspNetCore.Mvc.Formatters.Text.Yaml` packages. [[1]](diffhunk://#diff-98dbc16c509053f6437dc63d02a909897304ec54cd6a571af2e1e1d47c5e692dL1-R7) [[2]](diffhunk://#diff-95ec59fd3c07f1f9d3e803905e874e888fb0c482272ad17afb08258dd530978aL1-R7) [[3]](diffhunk://#diff-3f4266f265d93a90c6ea87525cc068f7558525869c6bc1961537842e133c9cd7L1-R7) [[4]](diffhunk://#diff-dbf4d29e13c032ecb6975f2fa3ddcf6fc3a531d1ca719899eb60e8727b2c9c35L1-R7)

Documentation updates:

* Added release notes for version 9.0.7 in `CHANGELOG.md`, highlighting the focus on package dependency updates.

Environment and infrastructure updates:

* Updated the Docker image version for the Ubuntu test environment in `testenvironments.json` to use a newer runner.
* Bumped the base NGINX version in `.docfx/Dockerfile.docfx` to `1.29.1-alpine` for improved security and compatibility.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - Upgraded multiple package dependencies to latest compatible versions.
  - Refreshed NGINX base image to the latest patch release.
  - Updated test environment runner image for .NET 8/9 maintenance.
  - Enabled an explicit build step in CI test job prior to running tests.
- Documentation
  - Added release notes for version 9.0.7 across packages (availability: .NET 9 and .NET 8; some include .NET Standard 2.0).
  - Updated changelog with 9.0.7 entry noting a service update focused on dependency refreshes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->