### PR TITLE
V9.0.8/service update

### DIFF
--- a/.nuget/Codebelt.Extensions.AspNetCore.Mvc.Formatters.Text.Yaml/PackageReleaseNotes.txt
+++ b/.nuget/Codebelt.Extensions.AspNetCore.Mvc.Formatters.Text.Yaml/PackageReleaseNotes.txt
@@ -1,4 +1,10 @@
-﻿Version 9.0.7
+﻿Version 9.0.8
+Availability: .NET 9 and .NET 8
+ 
+# ALM
+- CHANGED Dependencies have been upgraded to the latest compatible versions for all supported target frameworks (TFMs)
+ 
+Version 9.0.7
 Availability: .NET 9 and .NET 8
  
 # ALM

--- a/.nuget/Codebelt.Extensions.AspNetCore.Text.Yaml/PackageReleaseNotes.txt
+++ b/.nuget/Codebelt.Extensions.AspNetCore.Text.Yaml/PackageReleaseNotes.txt
@@ -1,4 +1,10 @@
-﻿Version 9.0.7
+﻿Version 9.0.8
+Availability: .NET 9 and .NET 8
+ 
+# ALM
+- CHANGED Dependencies have been upgraded to the latest compatible versions for all supported target frameworks (TFMs)
+ 
+Version 9.0.7
 Availability: .NET 9 and .NET 8
  
 # ALM

--- a/.nuget/Codebelt.Extensions.YamlDotNet.App/PackageReleaseNotes.txt
+++ b/.nuget/Codebelt.Extensions.YamlDotNet.App/PackageReleaseNotes.txt
@@ -1,4 +1,10 @@
-﻿Version 9.0.7
+﻿Version 9.0.8
+Availability: .NET 9 and .NET 8
+ 
+# ALM
+- CHANGED Dependencies have been upgraded to the latest compatible versions for all supported target frameworks (TFMs)
+ 
+Version 9.0.7
 Availability: .NET 9 and .NET 8
  
 # ALM

--- a/.nuget/Codebelt.Extensions.YamlDotNet/PackageReleaseNotes.txt
+++ b/.nuget/Codebelt.Extensions.YamlDotNet/PackageReleaseNotes.txt
@@ -1,4 +1,10 @@
-﻿Version 9.0.7
+﻿Version 9.0.8
+Availability: .NET 9, .NET 8 and .NET Standard 2.0
+ 
+# ALM
+- CHANGED Dependencies have been upgraded to the latest compatible versions for all supported target frameworks (TFMs)
+ 
+Version 9.0.7
 Availability: .NET 9, .NET 8 and .NET Standard 2.0
  
 # ALM

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ For more details, please refer to `PackageReleaseNotes.txt` on a per assembly ba
 > [!NOTE]  
 > Changelog entries prior to version 8.4.0 was migrated from previous versions of `Cuemon.Extensions.YamlDotNet`, `Cuemon.Extensions.AspNetCore`, `Cuemon.Extensions.AspNetCore.Mvc` and `Cuemon.Extensions.Diagnostics`.
 
+## [9.0.8] - 2025-10-20
+
+This is a service update that focuses on package dependencies.
+
 ## [9.0.7] - 2025-09-15
 
 This is a service update that focuses on package dependencies.

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,17 +3,17 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="Codebelt.Extensions.Xunit" Version="10.0.6" />
-    <PackageVersion Include="Codebelt.Extensions.Xunit.Hosting.AspNetCore" Version="10.0.6" />
-    <PackageVersion Include="Cuemon.AspNetCore" Version="9.0.9" />
-    <PackageVersion Include="Cuemon.AspNetCore.Mvc" Version="9.0.9" />
-    <PackageVersion Include="Cuemon.Extensions.AspNetCore" Version="9.0.9" />
-    <PackageVersion Include="Cuemon.Extensions.AspNetCore.Authentication" Version="9.0.9" />
-    <PackageVersion Include="Cuemon.Extensions.Core" Version="9.0.9" />
-    <PackageVersion Include="Cuemon.Extensions.DependencyInjection" Version="9.0.9" />
-    <PackageVersion Include="Cuemon.Extensions.IO" Version="9.0.9" />
-    <PackageVersion Include="Cuemon.Extensions.Reflection" Version="9.0.9" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageVersion Include="Codebelt.Extensions.Xunit" Version="10.0.7" />
+    <PackageVersion Include="Codebelt.Extensions.Xunit.Hosting.AspNetCore" Version="10.0.7" />
+    <PackageVersion Include="Cuemon.AspNetCore" Version="9.0.10" />
+    <PackageVersion Include="Cuemon.AspNetCore.Mvc" Version="9.0.10" />
+    <PackageVersion Include="Cuemon.Extensions.AspNetCore" Version="9.0.10" />
+    <PackageVersion Include="Cuemon.Extensions.AspNetCore.Authentication" Version="9.0.10" />
+    <PackageVersion Include="Cuemon.Extensions.Core" Version="9.0.10" />
+    <PackageVersion Include="Cuemon.Extensions.DependencyInjection" Version="9.0.10" />
+    <PackageVersion Include="Cuemon.Extensions.IO" Version="9.0.10" />
+    <PackageVersion Include="Cuemon.Extensions.Reflection" Version="9.0.10" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.0.0" />
     <PackageVersion Include="MinVer" Version="6.0.0" />
     <PackageVersion Include="System.Net.Http" Version="4.3.4" />
     <PackageVersion Include="YamlDotNet" Version="16.3.0" />
@@ -21,6 +21,6 @@
     <PackageVersion Include="coverlet.msbuild" Version="6.0.4" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.console" Version="2.9.3" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.4" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
   </ItemGroup>
 </Project>

--- a/testenvironments.json
+++ b/testenvironments.json
@@ -9,7 +9,7 @@
         {
             "name": "Docker-Ubuntu",
             "type": "docker",
-            "dockerImage": "gimlichael/ubuntu-testrunner:net8.0.414-9.0.305"
+            "dockerImage": "gimlichael/ubuntu-testrunner:net8.0.415-9.0.306"
         }
     ]
 }


### PR DESCRIPTION
This pull request is a service update focused on upgrading package dependencies to their latest compatible versions across all supported target frameworks. The changes affect package release notes, dependency versions, and the test environment configuration.

**Dependency upgrades**

* Updated multiple package dependencies to their latest compatible versions for all supported target frameworks in `.nuget/Codebelt.Extensions.AspNetCore.Mvc.Formatters.Text.Yaml/PackageReleaseNotes.txt`, `.nuget/Codebelt.Extensions.AspNetCore.Text.Yaml/PackageReleaseNotes.txt`, `.nuget/Codebelt.Extensions.YamlDotNet.App/PackageReleaseNotes.txt`, and `.nuget/Codebelt.Extensions.YamlDotNet/PackageReleaseNotes.txt`. [[1]](diffhunk://#diff-dbf4d29e13c032ecb6975f2fa3ddcf6fc3a531d1ca719899eb60e8727b2c9c35L1-R7) [[2]](diffhunk://#diff-3f4266f265d93a90c6ea87525cc068f7558525869c6bc1961537842e133c9cd7L1-R7) [[3]](diffhunk://#diff-95ec59fd3c07f1f9d3e803905e874e888fb0c482272ad17afb08258dd530978aL1-R7) [[4]](diffhunk://#diff-98dbc16c509053f6437dc63d02a909897304ec54cd6a571af2e1e1d47c5e692dL1-R7)
* Increased versions of several NuGet package dependencies in `Directory.Packages.props`, including `Codebelt.Extensions.Xunit`, `Cuemon.AspNetCore`, `Microsoft.NET.Test.Sdk`, and `xunit.runner.visualstudio`.

**Documentation updates**

* Added release notes for version 9.0.8 in `CHANGELOG.md` and updated per-assembly release notes to reflect dependency changes and availability for .NET 8/9 and .NET Standard 2.0. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR10-R13) [[2]](diffhunk://#diff-dbf4d29e13c032ecb6975f2fa3ddcf6fc3a531d1ca719899eb60e8727b2c9c35L1-R7) [[3]](diffhunk://#diff-3f4266f265d93a90c6ea87525cc068f7558525869c6bc1961537842e133c9cd7L1-R7) [[4]](diffhunk://#diff-95ec59fd3c07f1f9d3e803905e874e888fb0c482272ad17afb08258dd530978aL1-R7) [[5]](diffhunk://#diff-98dbc16c509053f6437dc63d02a909897304ec54cd6a571af2e1e1d47c5e692dL1-R7)

**Test environment update**

* Updated the Docker image for the Ubuntu test environment in `testenvironments.json` to use newer .NET and runner versions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Released version 9.0.8 with support for .NET 9 and .NET 8 (.NET Standard 2.0 for applicable packages).
  * Upgraded package dependencies to latest compatible versions across all supported target frameworks.
  * Updated test environment and development dependencies for improved testing infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->