### PR TITLE
V10.1.0/minimal api support

### DIFF
--- a/.github/scripts/bump-nuget.py
+++ b/.github/scripts/bump-nuget.py
@@ -1,26 +1,30 @@
 #!/usr/bin/env python3
 """
-Simplified package bumping for Codebelt service updates (Option B).
+Package bumping for Codebelt service updates.
 
-Only updates packages published by the triggering source repo.
+Updates packages published by the triggering source repo to the specified version.
+Additionally fetches the latest stable version from NuGet for all other Codebelt-related
+packages and updates them as well.
 Does NOT update Microsoft.Extensions.*, BenchmarkDotNet, or other third-party packages.
-Does NOT parse TFM conditions - only bumps Codebelt/Cuemon/Savvyio packages to the triggering version.
 
 Usage:
     TRIGGER_SOURCE=cuemon TRIGGER_VERSION=10.3.0 python3 bump-nuget.py
 
 Behavior:
 - If TRIGGER_SOURCE is "cuemon" and TRIGGER_VERSION is "10.3.0":
-  - Cuemon.Core: 10.2.1 → 10.3.0
-  - Cuemon.Extensions.IO: 10.2.1 → 10.3.0
+  - Cuemon.Core: 10.2.1 → 10.3.0  (triggered source, set to given version)
+  - Cuemon.Extensions.IO: 10.2.1 → 10.3.0  (triggered source, set to given version)
+  - Codebelt.Extensions.BenchmarkDotNet.*: 1.2.3 → <latest from NuGet>  (other Codebelt)
   - Microsoft.Extensions.Hosting: 9.0.13 → UNCHANGED (not a Codebelt package)
   - BenchmarkDotNet: 0.15.8 → UNCHANGED (not a Codebelt package)
 """
 
+import json
 import re
 import os
 import sys
-from typing import Dict, List
+import urllib.request
+from typing import Dict, List, Optional
 
 TRIGGER_SOURCE = os.environ.get("TRIGGER_SOURCE", "")
 TRIGGER_VERSION = os.environ.get("TRIGGER_VERSION", "")
@@ -31,21 +35,24 @@ SOURCE_PACKAGE_MAP: Dict[str, List[str]] = {
     "xunit": ["Codebelt.Extensions.Xunit"],
     "benchmarkdotnet": ["Codebelt.Extensions.BenchmarkDotNet"],
     "bootstrapper": ["Codebelt.Bootstrapper"],
+    "carter": ["Codebelt.Extensions.Carter"],
     "newtonsoft-json": [
         "Codebelt.Extensions.Newtonsoft.Json",
+        "Codebelt.Extensions.AspNetCore.Newtonsoft.Json",
         "Codebelt.Extensions.AspNetCore.Mvc.Formatters.Newtonsoft",
     ],
     "aws-signature-v4": ["Codebelt.Extensions.AspNetCore.Authentication.AwsSignature"],
     "unitify": ["Codebelt.Unitify"],
     "yamldotnet": [
         "Codebelt.Extensions.YamlDotNet",
+        "Codebelt.Extensions.AspNetCore.Text.Yaml",
         "Codebelt.Extensions.AspNetCore.Mvc.Formatters.Text.Yaml",
     ],
     "globalization": ["Codebelt.Extensions.Globalization"],
     "asp-versioning": ["Codebelt.Extensions.Asp.Versioning"],
     "swashbuckle-aspnetcore": ["Codebelt.Extensions.Swashbuckle"],
     "savvyio": ["Savvyio."],
-    "shared-kernel": [],
+    "shared-kernel": ["Codebelt.SharedKernel"],
 }
 
 
@@ -55,6 +62,38 @@ def is_triggered_package(package_name: str) -> bool:
         return False
     prefixes = SOURCE_PACKAGE_MAP.get(TRIGGER_SOURCE, [])
     return any(package_name.startswith(prefix) for prefix in prefixes)
+
+
+def is_codebelt_package(package_name: str) -> bool:
+    """Check if package belongs to any Codebelt repo (regardless of trigger source)."""
+    for repo_prefixes in SOURCE_PACKAGE_MAP.values():
+        if any(package_name.startswith(prefix) for prefix in repo_prefixes if prefix):
+            return True
+    return False
+
+
+_nuget_version_cache: Dict[str, Optional[str]] = {}
+
+
+def get_latest_nuget_version(package_name: str) -> Optional[str]:
+    """Fetch the latest stable version of a package from NuGet."""
+    if package_name in _nuget_version_cache:
+        return _nuget_version_cache[package_name]
+
+    url = f"https://api.nuget.org/v3-flatcontainer/{package_name.lower()}/index.json"
+    try:
+        with urllib.request.urlopen(url, timeout=15) as response:
+            data = json.loads(response.read())
+        versions = data.get("versions", [])
+        # Stable versions have no hyphen (no pre-release suffix)
+        stable = [v for v in versions if "-" not in v]
+        result = stable[-1] if stable else (versions[-1] if versions else None)
+    except Exception as exc:
+        print(f"  Warning: Could not fetch latest version for {package_name}: {exc}")
+        result = None
+
+    _nuget_version_cache[package_name] = result
+    return result
 
 
 def main():
@@ -70,7 +109,7 @@ def main():
     target_version = TRIGGER_VERSION.lstrip("v")
 
     print(f"Trigger: {TRIGGER_SOURCE} @ {target_version}")
-    print(f"Only updating packages from: {TRIGGER_SOURCE}")
+    print(f"Triggered packages set to {target_version}; other Codebelt packages fetched from NuGet.")
     print()
 
     try:
@@ -87,16 +126,24 @@ def main():
         pkg = m.group(1)
         current = m.group(2)
 
-        if not is_triggered_package(pkg):
-            skipped_third_party.append(f"  {pkg} (skipped - not from {TRIGGER_SOURCE})")
+        if is_triggered_package(pkg):
+            if target_version != current:
+                changes.append(f"  {pkg}: {current} → {target_version}")
+                return m.group(0).replace(
+                    f'Version="{current}"', f'Version="{target_version}"'
+                )
             return m.group(0)
 
-        if target_version != current:
-            changes.append(f"  {pkg}: {current} → {target_version}")
-            return m.group(0).replace(
-                f'Version="{current}"', f'Version="{target_version}"'
-            )
+        if is_codebelt_package(pkg):
+            latest = get_latest_nuget_version(pkg)
+            if latest and latest != current:
+                changes.append(f"  {pkg}: {current} → {latest} (latest from NuGet)")
+                return m.group(0).replace(
+                    f'Version="{current}"', f'Version="{latest}"'
+                )
+            return m.group(0)
 
+        skipped_third_party.append(f"  {pkg} (skipped - not a Codebelt package)")
         return m.group(0)
 
     # Match PackageVersion elements (handles multiline)
@@ -111,10 +158,10 @@ def main():
 
     # Show results
     if changes:
-        print(f"Updated {len(changes)} package(s) from {TRIGGER_SOURCE}:")
+        print(f"Updated {len(changes)} package(s):")
         print("\n".join(changes))
     else:
-        print(f"No packages from {TRIGGER_SOURCE} needed updating.")
+        print("No Codebelt packages needed updating.")
 
     if skipped_third_party:
         print()

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -13,7 +13,7 @@
     <PackageVersion Include="Cuemon.Extensions.DependencyInjection" Version="10.3.0" />
     <PackageVersion Include="Cuemon.Extensions.IO" Version="10.3.0" />
     <PackageVersion Include="Cuemon.Extensions.Reflection" Version="10.3.0" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
     <PackageVersion Include="MinVer" Version="7.0.0" />
     <PackageVersion Include="System.Net.Http" Version="4.3.4" />
     <PackageVersion Include="YamlDotNet" Version="16.3.0" />

--- a/src/Codebelt.Extensions.AspNetCore.Text.Yaml/Formatters/ServiceCollectionExtensions.cs
+++ b/src/Codebelt.Extensions.AspNetCore.Text.Yaml/Formatters/ServiceCollectionExtensions.cs
@@ -35,7 +35,7 @@ namespace Codebelt.Extensions.AspNetCore.Text.Yaml.Formatters
         {
             Validator.ThrowIfNull(services);
             Validator.ThrowIfInvalidConfigurator(setup, out var options);
-            services.Configure(setup ?? (o =>
+            services.TryConfigure(setup ?? (o =>
             {
                 o.Settings = options.Settings;
                 o.SensitivityDetails = options.SensitivityDetails;

--- a/src/Codebelt.Extensions.AspNetCore.Text.Yaml/ServiceCollectionExtensions.cs
+++ b/src/Codebelt.Extensions.AspNetCore.Text.Yaml/ServiceCollectionExtensions.cs
@@ -1,0 +1,29 @@
+using System;
+using Codebelt.Extensions.AspNetCore.Text.Yaml.Formatters;
+using Codebelt.Extensions.YamlDotNet.Formatters;
+using Cuemon;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Codebelt.Extensions.AspNetCore.Text.Yaml
+{
+    /// <summary>
+    /// Extension methods for the <see cref="IServiceCollection"/> interface.
+    /// </summary>
+    public static class ServiceCollectionExtensions
+    {
+        /// <summary>
+        /// Adds a <see cref="YamlFormatterOptions"/> service to the specified <see cref="IServiceCollection"/>.
+        /// </summary>
+        /// <param name="services">The <see cref="IServiceCollection"/> to add services to.</param>
+        /// <param name="setup">The <see cref="YamlFormatterOptions"/> which may be configured.</param>
+        /// <returns>An <see cref="IServiceCollection"/> that can be used to further configure other services.</returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="services"/> cannot be null.
+        /// </exception>
+        public static IServiceCollection AddMinimalYamlOptions(this IServiceCollection services, Action<YamlFormatterOptions> setup = null)
+        {
+            Validator.ThrowIfNull(services);
+            return services.AddYamlExceptionResponseFormatter(setup);
+        }
+    }
+}


### PR DESCRIPTION
This pull request updates the `.github/scripts/bump-nuget.py` script to improve how it manages package version bumps for Codebelt-related projects, adds a new extension method for minimal YAML options registration, and makes a minor dependency update. The main focus is on making the NuGet bumping process more robust and flexible by also updating all Codebelt packages to their latest stable NuGet versions, not just those from the triggering repo, and introducing new extension methods for easier service configuration.

**NuGet bump script improvements:**

* The bump script now updates all Codebelt-related packages to their latest stable NuGet version, not just those from the triggering source repo, while still skipping third-party dependencies. This includes fetching the latest version from NuGet for non-triggered Codebelt packages, improving dependency freshness and consistency. [[1]](diffhunk://#diff-685ff15518420b384a6763b52160c3f51d92f7b362b7e1aa10062557271a953dL3-R27) [[2]](diffhunk://#diff-685ff15518420b384a6763b52160c3f51d92f7b362b7e1aa10062557271a953dR67-R98) [[3]](diffhunk://#diff-685ff15518420b384a6763b52160c3f51d92f7b362b7e1aa10062557271a953dL73-R112) [[4]](diffhunk://#diff-685ff15518420b384a6763b52160c3f51d92f7b362b7e1aa10062557271a953dL90-R146) [[5]](diffhunk://#diff-685ff15518420b384a6763b52160c3f51d92f7b362b7e1aa10062557271a953dL114-R164)
* Added new package mappings in `SOURCE_PACKAGE_MAP` to support additional Codebelt packages such as `Codebelt.Extensions.Carter`, `Codebelt.Extensions.AspNetCore.Newtonsoft.Json`, `Codebelt.Extensions.AspNetCore.Text.Yaml`, and `Codebelt.SharedKernel`.

**Codebelt YAML formatter improvements:**

* Added a new extension method `AddMinimalYamlOptions` in `ServiceCollectionExtensions` to simplify registration of minimal YAML formatter options for ASP.NET Core services.
* Changed service registration in `AddYamlFormatterOptions` to use `TryConfigure` instead of `Configure`, improving compatibility with existing service configurations.

**Dependency update:**

* Bumped `Microsoft.NET.Test.Sdk` version from `18.0.1` to `18.3.0` in `Directory.Packages.props`.