### PR TITLE
V10.1.0/minimal api support

### DIFF
--- a/.docfx/Dockerfile.docfx
+++ b/.docfx/Dockerfile.docfx
@@ -3,7 +3,7 @@
 FROM --platform=$BUILDPLATFORM nginx:${NGINX_VERSION} AS base
 RUN rm -rf /usr/share/nginx/html/*
 
-FROM --platform=$BUILDPLATFORM codebeltnet/docfx:2.78.4 AS build
+FROM --platform=$BUILDPLATFORM codebeltnet/docfx:2.78.5 AS build
 
 ADD [".", "docfx"]
 

--- a/.nuget/Codebelt.Extensions.AspNetCore.Mvc.Formatters.Text.Yaml/PackageReleaseNotes.txt
+++ b/.nuget/Codebelt.Extensions.AspNetCore.Mvc.Formatters.Text.Yaml/PackageReleaseNotes.txt
@@ -1,4 +1,4 @@
-Version: 10.0.4
+Version: 10.1.0
 Availability: .NET 10 and .NET 9
  
 # ALM

--- a/.nuget/Codebelt.Extensions.AspNetCore.Text.Yaml/PackageReleaseNotes.txt
+++ b/.nuget/Codebelt.Extensions.AspNetCore.Text.Yaml/PackageReleaseNotes.txt
@@ -1,8 +1,14 @@
-Version: 10.0.4
+Version: 10.1.0
 Availability: .NET 10 and .NET 9
  
 # ALM
 - CHANGED Dependencies have been upgraded to the latest compatible versions for all supported target frameworks (TFMs)
+ 
+# New Features
+- ADDED ServiceCollectionExtensions class in the Codebelt.Extensions.AspNetCore.Text.Yaml namespace with AddMinimalYamlOptions method
+ 
+# Improvements
+- CHANGED ServiceCollectionExtensions class in the Codebelt.Extensions.AspNetCore.Text.Yaml.Formatters namespace so AddYamlFormatterOptions uses TryConfigure to avoid duplicate option registrations
  
 Version: 10.0.3
 Availability: .NET 10 and .NET 9

--- a/.nuget/Codebelt.Extensions.YamlDotNet.App/PackageReleaseNotes.txt
+++ b/.nuget/Codebelt.Extensions.YamlDotNet.App/PackageReleaseNotes.txt
@@ -1,4 +1,4 @@
-Version: 10.0.4
+Version: 10.1.0
 Availability: .NET 10 and .NET 9
  
 # ALM

--- a/.nuget/Codebelt.Extensions.YamlDotNet/PackageReleaseNotes.txt
+++ b/.nuget/Codebelt.Extensions.YamlDotNet/PackageReleaseNotes.txt
@@ -1,4 +1,4 @@
-Version: 10.0.4
+Version: 10.1.0
 Availability: .NET 10, .NET 9 and .NET Standard 2.0
  
 # ALM

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,21 @@ For more details, please refer to `PackageReleaseNotes.txt` on a per assembly ba
 > [!NOTE]  
 > Changelog entries prior to version 8.4.0 was migrated from previous versions of `Cuemon.Extensions.YamlDotNet`, `Cuemon.Extensions.AspNetCore`, `Cuemon.Extensions.AspNetCore.Mvc` and `Cuemon.Extensions.Diagnostics`.
 
-## [10.0.4] - 2026-02-28
+## [10.1.0] - 2026-02-28
 
-This is a service update that focuses on package dependencies.
+This is a minor release that improves minimal API formatter integration, while also tightening option registration behavior across ASP.NET Core formatter setup.
+
+### Added
+
+- `ServiceCollectionExtensions` class in the Codebelt.Extensions.AspNetCore.Text.Yaml namespace was extended with a new method: `AddMinimalYamlOptions`.
+
+### Changed
+
+- `ServiceCollectionExtensions` class in the Codebelt.Extensions.AspNetCore.Text.Yaml.Formatters namespace to use TryConfigure in `AddYamlFormatterOptions`.
+
+### Fixed
+
+- Prevented repeated `IConfigureOptions<TOptions>` registrations when formatter/options extension methods are called multiple times.
 
 ## [10.0.3] - 2026-02-20
 

--- a/test/Codebelt.Extensions.AspNetCore.Text.Yaml.Tests/Formatters/ServiceCollectionExtensionsTest.cs
+++ b/test/Codebelt.Extensions.AspNetCore.Text.Yaml.Tests/Formatters/ServiceCollectionExtensionsTest.cs
@@ -1,0 +1,61 @@
+using System;
+using System.Linq;
+using Codebelt.Extensions.Xunit;
+using Codebelt.Extensions.YamlDotNet.Formatters;
+using Cuemon.AspNetCore.Diagnostics;
+using Cuemon.Diagnostics;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace Codebelt.Extensions.AspNetCore.Text.Yaml.Formatters
+{
+    public class ServiceCollectionExtensionsTest : Test
+    {
+        public ServiceCollectionExtensionsTest(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [Fact]
+        public void AddYamlFormatterOptions_ShouldThrowArgumentNullException_WhenServicesIsNull()
+        {
+            Assert.Throws<ArgumentNullException>(() => ((IServiceCollection)null).AddYamlFormatterOptions());
+        }
+
+        [Fact]
+        public void AddYamlFormatterOptions_ShouldOnlyRegisterOptionsOnce()
+        {
+            var services = new ServiceCollection();
+            services.AddOptions();
+            services.AddYamlFormatterOptions(o => o.SensitivityDetails = FaultSensitivityDetails.All);
+            services.AddYamlFormatterOptions(o => o.SensitivityDetails = FaultSensitivityDetails.None);
+
+            var count = services.Count(sd => sd.ServiceType == typeof(IConfigureOptions<YamlFormatterOptions>));
+
+            TestOutput.WriteLine($"IConfigureOptions<YamlFormatterOptions> registration count: {count}");
+
+            Assert.Equal(1, count);
+        }
+
+        [Fact]
+        public void AddYamlExceptionResponseFormatter_ShouldThrowArgumentNullException_WhenServicesIsNull()
+        {
+            Assert.Throws<ArgumentNullException>(() => ((IServiceCollection)null).AddYamlExceptionResponseFormatter());
+        }
+
+        [Fact]
+        public void AddYamlExceptionResponseFormatter_ShouldOnlyRegisterFormatterOnce()
+        {
+            var services = new ServiceCollection();
+            services.AddOptions();
+            services.AddYamlExceptionResponseFormatter();
+            services.AddYamlExceptionResponseFormatter();
+
+            var count = services.Count(sd => sd.ServiceType == typeof(HttpExceptionDescriptorResponseFormatter<YamlFormatterOptions>));
+
+            TestOutput.WriteLine($"HttpExceptionDescriptorResponseFormatter<YamlFormatterOptions> registration count: {count}");
+
+            Assert.Equal(1, count);
+        }
+    }
+}

--- a/test/Codebelt.Extensions.AspNetCore.Text.Yaml.Tests/ServiceCollectionExtensionsTest.cs
+++ b/test/Codebelt.Extensions.AspNetCore.Text.Yaml.Tests/ServiceCollectionExtensionsTest.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Linq;
+using Codebelt.Extensions.AspNetCore.Text.Yaml.Formatters;
+using Codebelt.Extensions.Xunit;
+using Codebelt.Extensions.YamlDotNet.Formatters;
+using Cuemon.AspNetCore.Diagnostics;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Codebelt.Extensions.AspNetCore.Text.Yaml
+{
+    public class ServiceCollectionExtensionsTest : Test
+    {
+        public ServiceCollectionExtensionsTest(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [Fact]
+        public void AddMinimalYamlOptions_ShouldThrowArgumentNullException_WhenServicesIsNull()
+        {
+            Assert.Throws<ArgumentNullException>(() => ((IServiceCollection)null).AddMinimalYamlOptions());
+        }
+
+        [Fact]
+        public void AddMinimalYamlOptions_ShouldRegisterYamlExceptionResponseFormatter()
+        {
+            var services = new ServiceCollection();
+            services.AddOptions();
+            services.AddMinimalYamlOptions();
+
+            var count = services.Count(sd => sd.ServiceType == typeof(HttpExceptionDescriptorResponseFormatter<YamlFormatterOptions>));
+
+            TestOutput.WriteLine($"HttpExceptionDescriptorResponseFormatter<YamlFormatterOptions> registration count: {count}");
+
+            Assert.Equal(1, count);
+        }
+    }
+}


### PR DESCRIPTION
This pull request is a minor release focused on improving the ASP.NET Core YAML formatter integration and tightening option registration behavior. The main changes include the introduction of a new minimal API YAML options extension, enhancements to prevent duplicate option registrations, and the addition of related unit tests. Dependencies have also been updated.

**Formatter integration and extension improvements:**

* Added a new `ServiceCollectionExtensions` class in the `Codebelt.Extensions.AspNetCore.Text.Yaml` namespace with an `AddMinimalYamlOptions` method to simplify minimal API YAML formatter setup. [[1]](diffhunk://#diff-3f4266f265d93a90c6ea87525cc068f7558525869c6bc1961537842e133c9cd7L1-R12) [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edL10-R24) [[3]](diffhunk://#diff-f241d20f495af4bd7e2f3f46e331243bfab23e74e8ab197dd9379dc2a452afb7R1-R38)
* Changed the `ServiceCollectionExtensions` class in the `Codebelt.Extensions.AspNetCore.Text.Yaml.Formatters` namespace so that `AddYamlFormatterOptions` uses `TryConfigure` to avoid duplicate option registrations. [[1]](diffhunk://#diff-3f4266f265d93a90c6ea87525cc068f7558525869c6bc1961537842e133c9cd7L1-R12) [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edL10-R24)
* Fixed repeated `IConfigureOptions<TOptions>` registrations when formatter/options extension methods are called multiple times.

**Testing:**

* Added unit tests for the new and updated extension methods to verify correct exception handling and to ensure that options and formatters are registered only once. [[1]](diffhunk://#diff-be7f9eb07a3e36fde5bc8e12459aaf7f296ddc88bc9802fd9295646308f8bdb5R1-R61) [[2]](diffhunk://#diff-f241d20f495af4bd7e2f3f46e331243bfab23e74e8ab197dd9379dc2a452afb7R1-R38)

**Dependency and documentation updates:**

* Upgraded the `codebeltnet/docfx` Docker image from version 2.78.4 to 2.78.5 in `.docfx/Dockerfile.docfx`.
* Updated package release notes and version numbers for all affected NuGet packages to 10.1.0. [[1]](diffhunk://#diff-dbf4d29e13c032ecb6975f2fa3ddcf6fc3a531d1ca719899eb60e8727b2c9c35L1-R1) [[2]](diffhunk://#diff-3f4266f265d93a90c6ea87525cc068f7558525869c6bc1961537842e133c9cd7L1-R12) [[3]](diffhunk://#diff-95ec59fd3c07f1f9d3e803905e874e888fb0c482272ad17afb08258dd530978aL1-R1) [[4]](diffhunk://#diff-98dbc16c509053f6437dc63d02a909897304ec54cd6a571af2e1e1d47c5e692dL1-R1)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release v10.1.0

* **New Features**
  * Added new YAML options configuration method for ASP.NET Core integration.

* **Bug Fixes**
  * Improved option registration behavior to prevent duplicate registrations.

* **Chores**
  * Updated package version to 10.1.0 across related libraries.
  * Updated Docker build image version.
  * Enhanced documentation and changelog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->